### PR TITLE
Execute sequentially, even if no command specified

### DIFF
--- a/xssstart.c
+++ b/xssstart.c
@@ -66,6 +66,19 @@ sigchld(int sig)
 	}
 }
 
+static void
+run(const char* cmd, char *const argv[])
+{
+	switch ((child = fork())) {
+	case -1:
+		err(1, "fork");
+	case 0:
+		execvp(cmd, argv);
+		dpy = NULL;
+		err(1, "exec");
+	}
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -102,27 +115,13 @@ main(int argc, char *argv[])
 			if (deargi == 2 || (deargi > 2 && laststate == 1))
 				continue;
 			laststate = 1;
-			switch ((child = fork())) {
-			case -1:
-				err(1, "fork");
-			case 0:
-				execvp(argv[1], argv + 1);
-				dpy = NULL;
-				err(1, "exec");
-			}
+			run(argv[1], argv + 1);
 			break;
 		case ScreenSaverOff:
 			if (deargi < 0 || (deargi > 2 && laststate == 0))
 				continue;
 			laststate = 0;
-			switch ((child = fork())) {
-			case -1:
-				err(1, "fork");
-			case 0:
-				execvp(argv[deargi], argv + deargi);
-				dpy = NULL;
-				err(1, "exec");
-			}
+			run(argv[deargi], argv + deargi);
 			break;
 		}
 	}

--- a/xssstart.c
+++ b/xssstart.c
@@ -69,6 +69,8 @@ sigchld(int sig)
 static void
 run(const char* cmd, char *const argv[])
 {
+	if (child != 0)
+		return;
 	switch ((child = fork())) {
 	case -1:
 		err(1, "fork");
@@ -108,20 +110,20 @@ main(int argc, char *argv[])
 	if (sigaction(SIGCHLD, &act, NULL) == -1)
 		err(1, "sigaction");
 	while (XNextEvent(dpy, &ev) == 0) {
-		if (child != 0)
-			continue;
 		switch (((XScreenSaverNotifyEvent *)&ev)->state) {
 		case ScreenSaverOn:
-			if (deargi == 2 || (deargi > 2 && laststate == 1))
+			if (laststate == 1)
 				continue;
 			laststate = 1;
-			run(argv[1], argv + 1);
+			if (deargi > 2)
+				run(argv[1], argv + 1);
 			break;
 		case ScreenSaverOff:
-			if (deargi < 0 || (deargi > 2 && laststate == 0))
+			if (laststate == 0)
 				continue;
 			laststate = 0;
-			run(argv[deargi], argv + deargi);
+			if (deargi > 0)
+				run(argv[deargi], argv + deargi);
 			break;
 		}
 	}

--- a/xssstart.c
+++ b/xssstart.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 			if (laststate == 1)
 				continue;
 			laststate = 1;
-			if (deargi > 2)
+			if (deargi != 1)
 				run(argv[1], argv + 1);
 			break;
 		case ScreenSaverOff:


### PR DESCRIPTION
With only a ScreenSaverOff command specified, it was being run multiple times without the screen blanking first. This should fix that.